### PR TITLE
Add possibility to delete all radio controls from actual competition

### DIFF
--- a/web/adm/editComp.php
+++ b/web/adm/editComp.php
@@ -13,6 +13,10 @@ else if (isset($_GET['what']) && $_GET['what'] == "delctr")
 {
 	Emma::DelRadioControl($_GET['compid'],$_GET['code'],$_GET['class']);
 }
+else if (isset($_GET['what']) && $_GET['what'] == "delallctr")
+{
+	Emma::DelAllRadioControls($_GET['compid']);
+}
 
 
 include_once("../templates/emmalang_sv.php");
@@ -217,6 +221,11 @@ for ($i = 0; $i < sizeof($rcontrols); $i++)
 
 ?>
 </table>
+
+<br/><hr/>
+<a href='javascript:confirmDelete(\"Do you want to delete ALL radiocontrols?\",\"?compid=".$_GET['compid']."&what=delallctr&compid=".$_GET['compid']."\");'>Delete all radio controls</a>
+<br/><hr/><br/>
+
 <br/><b>Add Radio Control</b><br/>
 Code = 1000*passingcnt + controlCode, <br/>
 ex. first pass at control 53 => Code = 1053, second pass => Code = 2053<br/>

--- a/web/templates/classEmma.class.php
+++ b/web/templates/classEmma.class.php
@@ -109,9 +109,30 @@ $conn = mysql_connect(self::$db_server,self::$db_user,self::$db_pw);
 	 mysql_query("delete from splitcontrols where tavid=$compid and code=$code and classname='$classname'",$conn);
 
         }
+		
+	public static function DelAllRadioControls($compid)
+
+	{
+		$conn = mysql_connect(self::$db_server,self::$db_user,self::$db_pw);
+
+		mysql_select_db(self::$db_database);
+
+		if (mysql_errno()) {
+
+			printf("Connect failed: %s\n", mysql_error());
+
+			exit();
+
+		}
+
+		mysql_query("delete from splitcontrols where tavid=$compid",$conn);
+
+    }
+
 
 
 	public static function CreateCompetition($name,$org,$date)
+
         {
 
         $conn = mysql_connect(self::$db_server,self::$db_user,self::$db_pw);
@@ -128,40 +149,13 @@ $conn = mysql_connect(self::$db_server,self::$db_user,self::$db_pw);
 		}
 	 $res = mysql_query("select max(tavid)+1 from login",$conn);
 	 $id = mysql_result($res,0,0);
-	 if ($id < 10000)
+	if ($id < 10000)
 		$id = 10000;
 
 
 	 mysql_query("insert into login(tavid,user,pass,compName,organizer,compDate,public) values(".$id.",'".md5($name.$org.$date)."','".md5("liveresultat")."','".$name."','".$org."','".$date."',0)" ,$conn) or die(mysql_error());
 
 	}
-	
-	public static function CreateCompetitionFull($name,$org,$date, $email, $password, $country)
-    {
-
-        $conn = mysql_connect(self::$db_server,self::$db_user,self::$db_pw);
-
-	  mysql_select_db(self::$db_database);
-	  mysql_set_charset(self::$MYSQL_CHARSET,$conn);
-
-	  if (mysql_errno()) {
-
-	   		printf("Connect failed: %s\n", mysql_error());
-
-	   		exit();
-
-		}
-	 $res = mysql_query("select max(tavid)+1 from login",$conn);
-	 $id = mysql_result($res,0,0);
-	 if ($id < 10000)
-		$id = 10000;
-
-
-	 mysql_query("insert into login(tavid,user,pass,compName,organizer,compDate,public, country) values(".$id.",'".$email."','".md5($password)."','".$name."','".$org."','".$date."',0,'".$country."')" ,$conn) or die(mysql_error());
-	 	return $id;
-	}
-	
-	
 	public static function AddRadioControl($compid,$classname,$name,$code)
 
         {
@@ -259,7 +253,7 @@ public static function UpdateCompetition($id,$name,$org,$date,$public,$timediff)
 
 		}
 
-	 $result = mysql_query("select compName, compDate,tavid,organizer,public,timediff, timezone, videourl, videotype,multidaystage,multidayparent from login where tavid=$compid",$conn);
+	 $result = mysql_query("select compName, compDate,tavid,organizer,public,timediff, videourl, videotype,multidaystage,multidayparent from login where tavid=$compid",$conn);
 
          $ret = null;
 
@@ -418,27 +412,6 @@ public static function UpdateCompetition($id,$name,$org,$date,$public,$timediff)
 
 
 	}
-
-
-function getAllSplitControls()
-{
-	$ret = Array();
-	$q = "SELECT code, name,classname,corder from splitcontrols where tavid = " .$this->m_CompId. " order by corder";
-	if ($result = mysql_query($q))
-	{
-		while($tmp = mysql_fetch_array($result))
-		{
-			$ret[] = $tmp;
-		}
-		mysql_free_result($result);
-	} 
-	else
-	{ 
-		echo(mysql_error());
-	}
-	
-	return $ret;
-}
 
 
 


### PR DESCRIPTION
When you change radio control files (splitcodes.txt and splitnames.txt) and start emmaclient again, it double controls on web. So before second run you can delete all controls from web.