### PR TITLE
Fix retrieval of starttime and splittimes for non-internet date formats

### DIFF
--- a/H2Sharp/H2DataReader.cs
+++ b/H2Sharp/H2DataReader.cs
@@ -204,14 +204,22 @@ namespace System.Data.H2
         }
         public override int GetOrdinal(string name)
         {
-            for (int index = 0; index < Meta.getColumnCount(); ++index)
+            for (int index = 1; index <= Meta.getColumnCount(); ++index)
             {
                 if (Meta.getColumnName(index) == name)
                 {
-                    return index;
+                    return index-1;
                 }
             }
-            return -1;
+            string name2 = name.ToLower();
+            for (int index = 1; index <= Meta.getColumnCount(); ++index)
+            {
+                if (Meta.getColumnName(index).ToLower() == name2)
+                {
+                    return index - 1;
+                }
+            }
+            throw new IndexOutOfRangeException();
         }
         public override DataTable GetSchemaTable()
         {


### PR DESCRIPTION
Better version of PR #30 for fixing #28 which also works with H2 backend
For MySQL backend use the DateTime object directly and for H2 continue to use ParseDateTime()
This PR also fixes an issue with the implementation of H2DataReader.GetOrdinal() using invalid column indexes and not doing a case-insensitive lookup.