### PR TITLE
Fix start time priority order

### DIFF
--- a/H2Sharp/H2DataReader.cs
+++ b/H2Sharp/H2DataReader.cs
@@ -204,14 +204,22 @@ namespace System.Data.H2
         }
         public override int GetOrdinal(string name)
         {
-            for (int index = 0; index < Meta.getColumnCount(); ++index)
+            for (int index = 1; index <= Meta.getColumnCount(); ++index)
             {
                 if (Meta.getColumnName(index) == name)
                 {
-                    return index;
+                    return index-1;
                 }
             }
-            return -1;
+            string name2 = name.ToLower();
+            for (int index = 1; index <= Meta.getColumnCount(); ++index)
+            {
+                if (Meta.getColumnName(index).ToLower() == name2)
+                {
+                    return index - 1;
+                }
+            }
+            throw new IndexOutOfRangeException();
         }
         public override DataTable GetSchemaTable()
         {

--- a/LiveResults.Client/Parsers/OlaParser.cs
+++ b/LiveResults.Client/Parsers/OlaParser.cs
@@ -491,13 +491,13 @@ namespace LiveResults.Client
                                     //    startTime = ParseDateTime(tTime);
                                     //}
                                     //else 
-                                    if (reader[ordAllocatedStartTime] != null && reader[ordAllocatedStartTime] != DBNull.Value)
-                                    {
-                                        startTime = DBGetDateTime(reader, ordAllocatedStartTime);
-                                    }
-                                    else if (reader[ordStartTime] != null && reader[ordStartTime] != DBNull.Value)
+                                    if (reader[ordStartTime] != null && reader[ordStartTime] != DBNull.Value)
                                     {
                                         startTime = DBGetDateTime(reader, ordStartTime);
+                                    }
+                                    else if (reader[ordAllocatedStartTime] != null && reader[ordAllocatedStartTime] != DBNull.Value)
+                                    {
+                                        startTime = DBGetDateTime(reader, ordAllocatedStartTime);
                                     }
                                     else
                                     {


### PR DESCRIPTION
Change order of retrieval for allocatedStartTime and starttime to allow changes of starttime to go through when calculating new split times.
Depends on changes in PR #31 