### PR TITLE
Update H2 extension removal. 

### DIFF
--- a/LiveResults.Client/NewOLAComp.cs
+++ b/LiveResults.Client/NewOLAComp.cs
@@ -13,6 +13,7 @@ using System.Data.H2;
 using System.IO;
 using System.Xml.Serialization;
 using LiveResults.Model;
+using System.Text.RegularExpressions;
 
 namespace LiveResults.Client
 {
@@ -253,7 +254,7 @@ namespace LiveResults.Client
             switch (comboBox1.SelectedIndex)
             {
                 case 0:
-                    return new H2Connection("jdbc:h2://" + txtOlaDb.Text.Replace(".h2.db","") + ";AUTO_SERVER=TRUE", "root", "");
+                    return new H2Connection("jdbc:h2://" + Regex.Replace(txtOlaDb.Text, @"\.(h2|mv)\.db$", "") + ";AUTO_SERVER=TRUE", "root", "");
                 case 1:
                     return new MySql.Data.MySqlClient.MySqlConnection("Server=" + txtHost.Text + ";User Id=" + txtUser.Text + ";Port=" + txtPort.Text + ";Password=" + txtPw.Text + (schema != null ? ";Initial Catalog=" + schema : "") + ";charset=utf8;ConnectionTimeout=30");
                 case 2:
@@ -272,7 +273,7 @@ namespace LiveResults.Client
             IDbConnection conn = null;
             try
             {
-                if (comboBox1.SelectedIndex == 0 && !System.IO.File.Exists(txtOlaDb.Text.Replace(".h2.", ".lock.")))
+                if (comboBox1.SelectedIndex == 0 && !System.IO.File.Exists(Regex.Replace(txtOlaDb.Text, ".(h2|mv).", ".lock.")))
                 {
                     MessageBox.Show("OLA Does not seem to be started on server?\r\nPlease make sure OLA is running with connected clients when connecting, else all traffic will be redirected through this computer!");
                 }
@@ -292,7 +293,7 @@ namespace LiveResults.Client
                     if (ee.Message.ToUpper().Contains("ENOUGH RIGHTS"))
                     {
                         conn.Close();
-                        conn = new H2Connection("jdbc:h2://" + txtOlaDb.Text.Replace(".h2.db", "") + ";AUTO_SERVER=TRUE", "root", "");
+                        conn = new H2Connection("jdbc:h2://" + Regex.Replace(txtOlaDb.Text, @"\.(h2|mv)\.db$", "") + ";AUTO_SERVER=TRUE", "root", "");
                         try
                         {
                             conn.Open();


### PR DESCRIPTION
Make Emmaclient also replace the extension used by H2 with the MVStore format (.mv.db). This is used when creating a competition in OLA 5.10