### PR TITLE
change constructor of Emma class to __construct 

### DIFF
--- a/web/templates/classEmma.class.php
+++ b/web/templates/classEmma.class.php
@@ -416,7 +416,7 @@ function getAllSplitControls()
 
     $ret = Array();
 
-	$q = "SELECT runners.Name, runners.class, runners.Club, results.Time,results.Status, results.Changed, results.Control, splitcontrols.name as pname From results inner join runners on results.DbId = runners.DbId left join splitcontrols on (splitcontrols.code = results.Control and splitcontrols.tavid=".$this->m_CompId." and runners.class = splitcontrols.classname) where results.TavId =".$this->m_CompId." AND runners.TavId = results.TavId and results.Status <> -1 AND results.Time <> -1 AND results.Status <> 9 and results.Status <> 10 and results.control <> 100 and (results.control = 1000 or splitcontrols.tavid is not null) ORDER BY results.changed desc limit 3";
+	$q = "SELECT runners.Name, runners.class, runners.Club, results.Time,results.Status, results.Changed, results.Control, splitcontrols.name as pname From results inner join runners on results.DbId = runners.DbId left join splitcontrols on (splitcontrols.code = results.Control and splitcontrols.tavid=".$this->m_CompId." and runners.class = splitcontrols.classname) where results.TavId =".$this->m_CompId." AND runners.TavId = results.TavId and results.Status <> -1 AND results.Time <> -1 AND results.Status <> 9 and results.Status <> 10 and results.control <> 100 and (results.control = 1000 or splitcontrols.tavid is not null) ORDER BY results.changed desc limit ".$num;
 
 		if ($result = mysqli_query($this->m_Conn, $q))
 

--- a/web/templates/classEmma.class.php
+++ b/web/templates/classEmma.class.php
@@ -215,7 +215,7 @@ public static function UpdateCompetition($id,$name,$org,$date,$public,$timediff)
         }
 
 
-	function Emma($compID)
+	function __construct($compID)
 
 	{
 


### PR DESCRIPTION
In new version of PHP it is deprecated to have same name of function as class name - __construct() used.