### PR TITLE
Racom Parser - better result status parsing, new CSV startlist, use finish time from rawsplits

### DIFF
--- a/LiveResults.Client.Tests/LiveResults.Client.Tests.csproj
+++ b/LiveResults.Client.Tests/LiveResults.Client.Tests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>LiveResults.Client.Tests</RootNamespace>
     <AssemblyName>LiveResults.Client.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SccProjectName>

--- a/LiveResults.Client/App.config
+++ b/LiveResults.Client/App.config
@@ -10,4 +10,4 @@
     <add key="emmaServer2" value="54.247.102.48;liveresultat;web;liveresultat"/>-->
     
   </appSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/LiveResults.Client/FrmNewCompetition.cs
+++ b/LiveResults.Client/FrmNewCompetition.cs
@@ -120,7 +120,7 @@ namespace LiveResults.Client
             if (newRacomComp.ShowDialog(this) == DialogResult.OK)
             {
                 FrmMonitor monForm = new FrmMonitor();
-                monForm.SetParser(new RacomFileSetParser(newRacomComp.txtStartlist.Text, newRacomComp.txtRawSplits.Text, newRacomComp.txtRaceFile.Text,
+                monForm.SetParser(new RacomFileSetParser(newRacomComp.txtStartlist.Text, newRacomComp.cbStart.Checked, newRacomComp.txtRawSplits.Text, newRacomComp.txtRaceFile.Text,
                     newRacomComp.txtRadioControls.Text, newRacomComp.dtZeroTime.Value, newRacomComp.checkBox1.Checked));
                 monForm.CompetitionID = int.Parse(newRacomComp.txtCompID.Text);
                 monForm.ShowDialog(this);

--- a/LiveResults.Client/FrmNewCompetition.cs
+++ b/LiveResults.Client/FrmNewCompetition.cs
@@ -121,7 +121,7 @@ namespace LiveResults.Client
             {
                 FrmMonitor monForm = new FrmMonitor();
                 monForm.SetParser(new RacomFileSetParser(newRacomComp.txtStartlist.Text, newRacomComp.cbStart.Checked, newRacomComp.txtRawSplits.Text, newRacomComp.txtRaceFile.Text,
-                    newRacomComp.txtRadioControls.Text, newRacomComp.dtZeroTime.Value, newRacomComp.checkBox1.Checked));
+                    newRacomComp.txtRadioControls.Text, newRacomComp.dtZeroTime.Value, newRacomComp.checkBox1.Checked, Decimal.ToInt32(newRacomComp.numericUpDown1.Value)));
                 monForm.CompetitionID = int.Parse(newRacomComp.txtCompID.Text);
                 monForm.ShowDialog(this);
             }

--- a/LiveResults.Client/FrmNewRacomComp.Designer.cs
+++ b/LiveResults.Client/FrmNewRacomComp.Designer.cs
@@ -51,6 +51,9 @@
             this.btnSplits = new System.Windows.Forms.Button();
             this.btnFinish = new System.Windows.Forms.Button();
             this.btnSCodes = new System.Windows.Forms.Button();
+            this.label3 = new System.Windows.Forms.Label();
+            this.numericUpDown1 = new System.Windows.Forms.NumericUpDown();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).BeginInit();
             this.SuspendLayout();
             // 
             // label1
@@ -165,7 +168,7 @@
             this.txtCompID.Location = new System.Drawing.Point(20, 223);
             this.txtCompID.Margin = new System.Windows.Forms.Padding(4);
             this.txtCompID.Name = "txtCompID";
-            this.txtCompID.Size = new System.Drawing.Size(716, 22);
+            this.txtCompID.Size = new System.Drawing.Size(313, 22);
             this.txtCompID.TabIndex = 13;
             // 
             // label5
@@ -286,11 +289,44 @@
             this.btnSCodes.UseVisualStyleBackColor = true;
             this.btnSCodes.Click += new System.EventHandler(this.btnSCodes_Click);
             // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(526, 203);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(162, 17);
+            this.label3.TabIndex = 25;
+            this.label3.Text = "Control number of Finish";
+            // 
+            // numericUpDown1
+            // 
+            this.numericUpDown1.Location = new System.Drawing.Point(529, 224);
+            this.numericUpDown1.Maximum = new decimal(new int[] {
+            30,
+            0,
+            0,
+            0});
+            this.numericUpDown1.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.numericUpDown1.Name = "numericUpDown1";
+            this.numericUpDown1.Size = new System.Drawing.Size(207, 22);
+            this.numericUpDown1.TabIndex = 26;
+            this.numericUpDown1.Value = new decimal(new int[] {
+            2,
+            0,
+            0,
+            0});
+            // 
             // FrmNewRacomComp
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(753, 374);
+            this.Controls.Add(this.numericUpDown1);
+            this.Controls.Add(this.label3);
             this.Controls.Add(this.btnSCodes);
             this.Controls.Add(this.btnFinish);
             this.Controls.Add(this.btnSplits);
@@ -316,6 +352,7 @@
             this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "FrmNewRacomComp";
             this.Text = "New Racom Connection";
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -346,5 +383,7 @@
         private System.Windows.Forms.Button btnSplits;
         private System.Windows.Forms.Button btnFinish;
         private System.Windows.Forms.Button btnSCodes;
+        private System.Windows.Forms.Label label3;
+        public System.Windows.Forms.NumericUpDown numericUpDown1;
     }
 }

--- a/LiveResults.Client/FrmNewRacomComp.Designer.cs
+++ b/LiveResults.Client/FrmNewRacomComp.Designer.cs
@@ -46,14 +46,20 @@
             this.btn_loadsetting = new System.Windows.Forms.Button();
             this.openSettingsDialog = new System.Windows.Forms.OpenFileDialog();
             this.button3 = new System.Windows.Forms.Button();
+            this.btnStart = new System.Windows.Forms.Button();
+            this.cbStart = new System.Windows.Forms.CheckBox();
+            this.btnSplits = new System.Windows.Forms.Button();
+            this.btnFinish = new System.Windows.Forms.Button();
+            this.btnSCodes = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(12, 9);
+            this.label1.Location = new System.Drawing.Point(16, 11);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(41, 13);
+            this.label1.Size = new System.Drawing.Size(55, 17);
             this.label1.TabIndex = 0;
             this.label1.Text = "Startlist";
             // 
@@ -61,26 +67,29 @@
             // 
             this.txtStartlist.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtStartlist.Location = new System.Drawing.Point(15, 25);
+            this.txtStartlist.Location = new System.Drawing.Point(20, 31);
+            this.txtStartlist.Margin = new System.Windows.Forms.Padding(4);
             this.txtStartlist.Name = "txtStartlist";
-            this.txtStartlist.Size = new System.Drawing.Size(538, 20);
+            this.txtStartlist.Size = new System.Drawing.Size(716, 22);
             this.txtStartlist.TabIndex = 1;
             // 
             // txtRawSplits
             // 
             this.txtRawSplits.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtRawSplits.Location = new System.Drawing.Point(15, 64);
+            this.txtRawSplits.Location = new System.Drawing.Point(20, 79);
+            this.txtRawSplits.Margin = new System.Windows.Forms.Padding(4);
             this.txtRawSplits.Name = "txtRawSplits";
-            this.txtRawSplits.Size = new System.Drawing.Size(538, 20);
+            this.txtRawSplits.Size = new System.Drawing.Size(716, 22);
             this.txtRawSplits.TabIndex = 3;
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(12, 48);
+            this.label2.Location = new System.Drawing.Point(16, 59);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(55, 13);
+            this.label2.Size = new System.Drawing.Size(71, 17);
             this.label2.TabIndex = 2;
             this.label2.Text = "Raw splits";
             // 
@@ -88,17 +97,19 @@
             // 
             this.txtRaceFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtRaceFile.Location = new System.Drawing.Point(15, 103);
+            this.txtRaceFile.Location = new System.Drawing.Point(20, 127);
+            this.txtRaceFile.Margin = new System.Windows.Forms.Padding(4);
             this.txtRaceFile.Name = "txtRaceFile";
-            this.txtRaceFile.Size = new System.Drawing.Size(538, 20);
+            this.txtRaceFile.Size = new System.Drawing.Size(716, 22);
             this.txtRaceFile.TabIndex = 5;
             // 
             // Resultfile
             // 
             this.Resultfile.AutoSize = true;
-            this.Resultfile.Location = new System.Drawing.Point(12, 87);
+            this.Resultfile.Location = new System.Drawing.Point(16, 107);
+            this.Resultfile.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.Resultfile.Name = "Resultfile";
-            this.Resultfile.Size = new System.Drawing.Size(112, 13);
+            this.Resultfile.Size = new System.Drawing.Size(151, 17);
             this.Resultfile.TabIndex = 4;
             this.Resultfile.Text = "Race file (Finish times)";
             // 
@@ -106,17 +117,19 @@
             // 
             this.txtRadioControls.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtRadioControls.Location = new System.Drawing.Point(15, 142);
+            this.txtRadioControls.Location = new System.Drawing.Point(20, 175);
+            this.txtRadioControls.Margin = new System.Windows.Forms.Padding(4);
             this.txtRadioControls.Name = "txtRadioControls";
-            this.txtRadioControls.Size = new System.Drawing.Size(538, 20);
+            this.txtRadioControls.Size = new System.Drawing.Size(716, 22);
             this.txtRadioControls.TabIndex = 9;
             // 
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(12, 126);
+            this.label4.Location = new System.Drawing.Point(16, 155);
+            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(464, 13);
+            this.label4.Size = new System.Drawing.Size(624, 17);
             this.label4.TabIndex = 8;
             this.label4.Text = "Intermediate control file (<XYZ>.splitcodes.txt && need also <XYZ>.splitnames.txt" +
     " in same directory)";
@@ -125,9 +138,10 @@
             // 
             this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.button1.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.button1.Location = new System.Drawing.Point(397, 269);
+            this.button1.Location = new System.Drawing.Point(529, 331);
+            this.button1.Margin = new System.Windows.Forms.Padding(4);
             this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(75, 23);
+            this.button1.Size = new System.Drawing.Size(100, 28);
             this.button1.TabIndex = 10;
             this.button1.Text = "&OK";
             this.button1.UseVisualStyleBackColor = true;
@@ -136,9 +150,10 @@
             // 
             this.button2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.button2.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.button2.Location = new System.Drawing.Point(478, 269);
+            this.button2.Location = new System.Drawing.Point(637, 331);
+            this.button2.Margin = new System.Windows.Forms.Padding(4);
             this.button2.Name = "button2";
-            this.button2.Size = new System.Drawing.Size(75, 23);
+            this.button2.Size = new System.Drawing.Size(100, 28);
             this.button2.TabIndex = 11;
             this.button2.Text = "&Cancel";
             this.button2.UseVisualStyleBackColor = true;
@@ -147,26 +162,29 @@
             // 
             this.txtCompID.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtCompID.Location = new System.Drawing.Point(15, 181);
+            this.txtCompID.Location = new System.Drawing.Point(20, 223);
+            this.txtCompID.Margin = new System.Windows.Forms.Padding(4);
             this.txtCompID.Name = "txtCompID";
-            this.txtCompID.Size = new System.Drawing.Size(538, 20);
+            this.txtCompID.Size = new System.Drawing.Size(716, 22);
             this.txtCompID.TabIndex = 13;
             // 
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(12, 165);
+            this.label5.Location = new System.Drawing.Point(16, 203);
+            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(180, 13);
+            this.label5.Size = new System.Drawing.Size(238, 17);
             this.label5.TabIndex = 12;
             this.label5.Text = "CompetitionID (Emma web server ID)";
             // 
             // label6
             // 
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(12, 204);
+            this.label6.Location = new System.Drawing.Point(16, 251);
+            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(48, 13);
+            this.label6.Size = new System.Drawing.Size(64, 17);
             this.label6.TabIndex = 14;
             this.label6.Text = "Zerotime";
             // 
@@ -174,26 +192,29 @@
             // 
             this.dtZeroTime.CustomFormat = "yyyy-MM-dd HH:mm:ss";
             this.dtZeroTime.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.dtZeroTime.Location = new System.Drawing.Point(15, 220);
+            this.dtZeroTime.Location = new System.Drawing.Point(20, 271);
+            this.dtZeroTime.Margin = new System.Windows.Forms.Padding(4);
             this.dtZeroTime.Name = "dtZeroTime";
-            this.dtZeroTime.Size = new System.Drawing.Size(236, 20);
+            this.dtZeroTime.Size = new System.Drawing.Size(313, 22);
             this.dtZeroTime.TabIndex = 15;
             // 
             // checkBox1
             // 
             this.checkBox1.AutoSize = true;
-            this.checkBox1.Location = new System.Drawing.Point(15, 246);
+            this.checkBox1.Location = new System.Drawing.Point(20, 303);
+            this.checkBox1.Margin = new System.Windows.Forms.Padding(4);
             this.checkBox1.Name = "checkBox1";
-            this.checkBox1.Size = new System.Drawing.Size(61, 17);
+            this.checkBox1.Size = new System.Drawing.Size(76, 21);
             this.checkBox1.TabIndex = 16;
             this.checkBox1.Text = "IsRelay";
             this.checkBox1.UseVisualStyleBackColor = true;
             // 
             // btn_loadsetting
             // 
-            this.btn_loadsetting.Location = new System.Drawing.Point(12, 269);
+            this.btn_loadsetting.Location = new System.Drawing.Point(16, 331);
+            this.btn_loadsetting.Margin = new System.Windows.Forms.Padding(4);
             this.btn_loadsetting.Name = "btn_loadsetting";
-            this.btn_loadsetting.Size = new System.Drawing.Size(124, 23);
+            this.btn_loadsetting.Size = new System.Drawing.Size(165, 28);
             this.btn_loadsetting.TabIndex = 18;
             this.btn_loadsetting.Text = "Load settings from file";
             this.btn_loadsetting.UseVisualStyleBackColor = true;
@@ -206,19 +227,75 @@
             // 
             // button3
             // 
-            this.button3.Location = new System.Drawing.Point(142, 269);
+            this.button3.Location = new System.Drawing.Point(189, 331);
+            this.button3.Margin = new System.Windows.Forms.Padding(4);
             this.button3.Name = "button3";
-            this.button3.Size = new System.Drawing.Size(120, 23);
+            this.button3.Size = new System.Drawing.Size(160, 28);
             this.button3.TabIndex = 19;
             this.button3.Text = "Save settings to file";
             this.button3.UseVisualStyleBackColor = true;
             this.button3.Click += new System.EventHandler(this.button3_Click);
             // 
+            // btnStart
+            // 
+            this.btnStart.Location = new System.Drawing.Point(710, 10);
+            this.btnStart.Name = "btnStart";
+            this.btnStart.Size = new System.Drawing.Size(27, 13);
+            this.btnStart.TabIndex = 20;
+            this.btnStart.Text = "...";
+            this.btnStart.UseVisualStyleBackColor = true;
+            this.btnStart.Click += new System.EventHandler(this.btnStart_Click);
+            // 
+            // cbStart
+            // 
+            this.cbStart.AutoSize = true;
+            this.cbStart.Location = new System.Drawing.Point(293, 10);
+            this.cbStart.Name = "cbStart";
+            this.cbStart.Size = new System.Drawing.Size(243, 21);
+            this.cbStart.TabIndex = 21;
+            this.cbStart.Text = "Use extended csv file read (2023)";
+            this.cbStart.UseVisualStyleBackColor = true;
+            // 
+            // btnSplits
+            // 
+            this.btnSplits.Location = new System.Drawing.Point(710, 59);
+            this.btnSplits.Name = "btnSplits";
+            this.btnSplits.Size = new System.Drawing.Size(27, 13);
+            this.btnSplits.TabIndex = 22;
+            this.btnSplits.Text = "...";
+            this.btnSplits.UseVisualStyleBackColor = true;
+            this.btnSplits.Click += new System.EventHandler(this.btnSplits_Click);
+            // 
+            // btnFinish
+            // 
+            this.btnFinish.Location = new System.Drawing.Point(709, 107);
+            this.btnFinish.Name = "btnFinish";
+            this.btnFinish.Size = new System.Drawing.Size(27, 13);
+            this.btnFinish.TabIndex = 23;
+            this.btnFinish.Text = "...";
+            this.btnFinish.UseVisualStyleBackColor = true;
+            this.btnFinish.Click += new System.EventHandler(this.btnFinish_Click);
+            // 
+            // btnSCodes
+            // 
+            this.btnSCodes.Location = new System.Drawing.Point(709, 155);
+            this.btnSCodes.Name = "btnSCodes";
+            this.btnSCodes.Size = new System.Drawing.Size(27, 13);
+            this.btnSCodes.TabIndex = 24;
+            this.btnSCodes.Text = "...";
+            this.btnSCodes.UseVisualStyleBackColor = true;
+            this.btnSCodes.Click += new System.EventHandler(this.btnSCodes_Click);
+            // 
             // FrmNewRacomComp
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(565, 304);
+            this.ClientSize = new System.Drawing.Size(753, 374);
+            this.Controls.Add(this.btnSCodes);
+            this.Controls.Add(this.btnFinish);
+            this.Controls.Add(this.btnSplits);
+            this.Controls.Add(this.cbStart);
+            this.Controls.Add(this.btnStart);
             this.Controls.Add(this.button3);
             this.Controls.Add(this.btn_loadsetting);
             this.Controls.Add(this.checkBox1);
@@ -236,6 +313,7 @@
             this.Controls.Add(this.label2);
             this.Controls.Add(this.txtStartlist);
             this.Controls.Add(this.label1);
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "FrmNewRacomComp";
             this.Text = "New Racom Connection";
             this.ResumeLayout(false);
@@ -263,5 +341,10 @@
         private System.Windows.Forms.Button btn_loadsetting;
         private System.Windows.Forms.OpenFileDialog openSettingsDialog;
         private System.Windows.Forms.Button button3;
+        private System.Windows.Forms.Button btnStart;
+        public System.Windows.Forms.CheckBox cbStart;
+        private System.Windows.Forms.Button btnSplits;
+        private System.Windows.Forms.Button btnFinish;
+        private System.Windows.Forms.Button btnSCodes;
     }
 }

--- a/LiveResults.Client/FrmNewRacomComp.cs
+++ b/LiveResults.Client/FrmNewRacomComp.cs
@@ -39,7 +39,7 @@ namespace LiveResults.Client
                         txtCompID.Text = s.CompetitionID;
                         dtZeroTime.Value = s.zeroTime;
                         checkBox1.Checked = s.IsRelay;
-
+                        numericUpDown1.Value = s.FinishCode;
                     }
                 }
                 catch
@@ -70,16 +70,16 @@ namespace LiveResults.Client
         {
             try
             {
-                var s = new Settings{
+                var s = new Settings {
                     StartlistFile = txtStartlist.Text,
                     UseCsvStartlist = cbStart.Checked,
                     CompetitionID = txtCompID.Text,
                     RaceFile = txtRaceFile.Text,
                     RadioControlFile = txtRadioControls.Text,
-                    RawSplitsFile = txtRawSplits.Text
-                    ,
+                    RawSplitsFile = txtRawSplits.Text,
                     zeroTime = dtZeroTime.Value,
-                    IsRelay = checkBox1.Checked
+                    IsRelay = checkBox1.Checked,
+                    FinishCode = Decimal.ToInt32(numericUpDown1.Value)
                 };
 
                 
@@ -103,6 +103,7 @@ namespace LiveResults.Client
             public string RadioControlFile { get; set; }
             public string CompetitionID { get; set; }
             public bool IsRelay { get; set; }
+            public int FinishCode { get; set; }
         }
 
         private void btn_loadsetting_Click(object sender, EventArgs e)

--- a/LiveResults.Client/FrmNewRacomComp.cs
+++ b/LiveResults.Client/FrmNewRacomComp.cs
@@ -33,6 +33,7 @@ namespace LiveResults.Client
                     {
                         txtStartlist.Text = s.StartlistFile;
                         txtRawSplits.Text = s.RawSplitsFile;
+                        cbStart.Checked = s.UseCsvStartlist;
                         txtRadioControls.Text = s.RadioControlFile;
                         txtRaceFile.Text = s.RaceFile;
                         txtCompID.Text = s.CompetitionID;
@@ -71,6 +72,7 @@ namespace LiveResults.Client
             {
                 var s = new Settings{
                     StartlistFile = txtStartlist.Text,
+                    UseCsvStartlist = cbStart.Checked,
                     CompetitionID = txtCompID.Text,
                     RaceFile = txtRaceFile.Text,
                     RadioControlFile = txtRadioControls.Text,
@@ -95,6 +97,7 @@ namespace LiveResults.Client
         {
             public DateTime zeroTime { get; set; }
             public string StartlistFile { get; set; }
+            public bool UseCsvStartlist { get; set; }
             public string RaceFile { get; set; }
             public string RawSplitsFile { get; set; }
             public string RadioControlFile { get; set; }
@@ -120,6 +123,49 @@ namespace LiveResults.Client
                 MessageBox.Show(this, "File saved!", "Save settings", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
         }
-       
+
+        private void btnStart_Click(object sender, EventArgs e)
+        {
+            OpenFileDialog ofd = new OpenFileDialog();
+            ofd.Filter = "TXT-files|*.txt|CSV-files|*.csv";
+            if (txtStartlist.Text.Length > 0)
+                ofd.InitialDirectory = Directory.GetParent(txtStartlist.Text).FullName;
+            ofd.FileName = txtStartlist.Text;
+            if (ofd.ShowDialog(this) == DialogResult.OK)
+                txtStartlist.Text = ofd.FileName;
+        }
+
+        private void btnSCodes_Click(object sender, EventArgs e)
+        {
+            OpenFileDialog ofd = new OpenFileDialog();
+            ofd.Filter = "TXT-files|*.splitcodes.txt";
+            if (txtRadioControls.Text.Length > 0)
+                ofd.InitialDirectory = Directory.GetParent(txtRadioControls.Text).FullName;
+            ofd.FileName = txtRadioControls.Text;
+            if (ofd.ShowDialog(this) == DialogResult.OK)
+                txtRadioControls.Text = ofd.FileName;
+        }
+
+        private void btnFinish_Click(object sender, EventArgs e)
+        {
+            OpenFileDialog ofd = new OpenFileDialog();
+            ofd.Filter = "TXT-files|*.txt";
+            if (txtRaceFile.Text.Length > 0)
+                ofd.InitialDirectory = Directory.GetParent(txtRaceFile.Text).FullName;
+            ofd.FileName = txtRaceFile.Text;
+            if (ofd.ShowDialog(this) == DialogResult.OK)
+                txtRaceFile.Text = ofd.FileName;
+        }
+
+        private void btnSplits_Click(object sender, EventArgs e)
+        {
+            OpenFileDialog ofd = new OpenFileDialog();
+            ofd.Filter = "TXT-files|*.txt";
+            if (txtRawSplits.Text.Length > 0)
+                ofd.InitialDirectory = Directory.GetParent(txtRawSplits.Text).FullName;
+            ofd.FileName = txtRawSplits.Text;
+            if (ofd.ShowDialog(this) == DialogResult.OK)
+                txtRawSplits.Text = ofd.FileName;
+        }
     }
 }

--- a/LiveResults.Client/LiveResults.Client.csproj
+++ b/LiveResults.Client/LiveResults.Client.csproj
@@ -24,7 +24,7 @@
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>
     </AssemblyOriginatorKeyFile>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <PublishUrl>c:\OpenSource\EmmaPublishCombined\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Web</InstallFrom>

--- a/LiveResults.Client/Parsers/RacomFileSetParser.cs
+++ b/LiveResults.Client/Parsers/RacomFileSetParser.cs
@@ -12,6 +12,7 @@ namespace LiveResults.Client.Parsers
     public class RacomFileSetParser : IExternalSystemResultParser
     {
         private readonly string m_startListFile;
+        private readonly bool m_useCsvStartlist;
         private readonly string m_splitsFile;
         private readonly string m_finishFile;
         private readonly string m_radioDefinitionFile;
@@ -21,9 +22,10 @@ namespace LiveResults.Client.Parsers
         {
         }
 
-        public RacomFileSetParser(string startlistFile, string splitsFile, string finishFile, string radioDefinitionFile, DateTime zeroTime, bool isRelay)
+        public RacomFileSetParser(string startlistFile, bool useCsvStartlist, string splitsFile, string finishFile, string radioDefinitionFile, DateTime zeroTime, bool isRelay)
         {
             m_startListFile = startlistFile;
+            m_useCsvStartlist = useCsvStartlist;
             m_splitsFile = splitsFile;
             m_finishFile = finishFile;
             m_radioDefinitionFile = radioDefinitionFile;
@@ -48,12 +50,15 @@ namespace LiveResults.Client.Parsers
 
 
 
-        public Runner[] ParseFiles(DateTime zeroTime, string startlistFile, string splitsFile, string finFile)
+        public Runner[] ParseFiles(DateTime zeroTime, string startlistFile, string splitsFile, string finFile, bool useCsvStartlist)
         {
             var ret = new List<Runner>();
             var siToRunner = new Dictionary<int, Runner>();
             var enc = Encoding.GetEncoding("Windows-1250");
-            ReadStartList(zeroTime, startlistFile, ret, siToRunner,enc);
+            if (useCsvStartlist)
+                ReadStartListCsvUtf8(zeroTime, startlistFile, ret, siToRunner);
+            else
+                ReadStartList(zeroTime, startlistFile, ret, siToRunner, enc);
             //ReadAndApplyRaceFile(raceFile, ret, enc);
             ReadAndApplyFINFile(finFile, siToRunner, enc);
             ReadAndApplySplitsFile(splitsFile, siToRunner,enc);
@@ -188,7 +193,7 @@ namespace LiveResults.Client.Parsers
                         var code = int.Parse(tmp.Substring(idxColon + 1, idxSlash - idxColon-1));
                         string time = tmp.Substring(idxSlash + 1);
 
-                        if (!siToRunner.ContainsKey(si))
+                        if (!siToRunner.ContainsKey(si) || time == "No time ")
                         {
                             continue;
                         }
@@ -312,11 +317,85 @@ namespace LiveResults.Client.Parsers
                                 OnLogMessage("Duplicate SI-NO: " + sinr + ", skipping " + name);
                         }
                     }
-                    catch (System.Exception ex)
+                    catch (System.Exception)
                     {
                         if (OnLogMessage != null)
                             OnLogMessage("Parsing start list error on line : " + tmp);
                     }
+                }
+            }
+        }
+
+        private void ReadStartListCsvUtf8(DateTime zeroTime, string startlistFile, List<Runner> ret, Dictionary<int, Runner> siToRunner)
+        {
+            if (!System.IO.File.Exists(startlistFile))
+            {
+                if (OnLogMessage != null)
+                    OnLogMessage("Read StartList - file not found");
+                return;
+            }
+            var csvRows = System.IO.File.ReadAllLines(startlistFile, Encoding.UTF8).ToList();
+            foreach (var row in csvRows.Skip(1))    // first row is header
+            {
+                var columns = row.Split(';');
+                if (columns.Length < 7)
+                {
+                    if (OnLogMessage != null)
+                        OnLogMessage("Incorrect start line columns count! (" + columns.Length + ")");
+                }
+                try
+                {
+                    // columns are :
+                    // ID, Class, SI, Name, Starttime, Club, Bib, [Leg]
+                    string id = columns[0].Trim();
+                    string stnr = columns[6].Trim();
+                    string sinr = columns[2].Trim();
+                    string className = columns[1].Trim();
+                    string name = columns[3].Trim();
+                    string start = columns[4].Trim();
+                    string club = columns[5].Trim();
+                    int leg = 0;
+                    if (columns.Length > 7)
+                        leg = int.Parse(columns[7].Trim());
+
+                    if (string.IsNullOrEmpty(id))
+                    {
+                        if (OnLogMessage != null)
+                            OnLogMessage("Startnumber empty: runner: " + name + " in class " + className);
+                        continue;
+                    }
+
+                    int dbId = m_isRelay ? leg * 100000 + int.Parse(id) : int.Parse(id);
+                    var r = new RacomRunner(int.Parse(stnr), dbId, name, club, className, m_isRelay ? (int?)leg : null);
+
+                    if (m_isRelay)
+                    {
+                        r.ClassWithoutLeg = className;
+                        if (!string.IsNullOrEmpty(r.ClassWithoutLeg))
+                            r.ClassWithoutLeg = r.ClassWithoutLeg.Trim();
+
+                        r.Class = r.ClassWithoutLeg + " " + leg;
+                    }
+
+                    var startTime = zeroTime.AddSeconds(parseTime(start));
+                    r.SetStartTime(startTime.Hour * 360000 + startTime.Minute * 6000 + startTime.Second * 100 + startTime.Millisecond / 10);
+                    r.SetResult(-9, 9);
+
+                    ret.Add(r);
+                    if (!siToRunner.ContainsKey(int.Parse(sinr)))
+                    {
+                        siToRunner.Add(int.Parse(sinr), r);
+                    }
+                    else
+                    {
+                        if (OnLogMessage != null)
+                            OnLogMessage("Duplicate SI-NO: " + sinr + ", skipping " + name);
+                    }
+                }
+                catch (System.Exception)
+                {
+                    if (OnLogMessage != null)
+                        OnLogMessage("Parsing start list error on line : " + row);
                 }
             }
         }
@@ -444,7 +523,7 @@ namespace LiveResults.Client.Parsers
                     {
 
                     
-                    var runners = ParseFiles(m_zeroTime, m_startListFile, m_splitsFile, m_finishFile);
+                    var runners = ParseFiles(m_zeroTime, m_startListFile, m_splitsFile, m_finishFile, m_useCsvStartlist);
                     if (OnResult != null)
                     {
                         foreach (var r in runners)

--- a/LiveResults.Client/Parsers/RacomFileSetParser.cs
+++ b/LiveResults.Client/Parsers/RacomFileSetParser.cs
@@ -113,24 +113,42 @@ namespace LiveResults.Client.Parsers
                         string time = tmp.Substring(idxSlash + 1, idxSlash2 - idxSlash - 1).Trim();
                         string status = tmp.Substring(idxSlash2 + 1).Trim();
 
-                        
-
                         if (!siToRunner.ContainsKey(si))
                         {
                             continue;
                         }
 
-
-
                         var runner = siToRunner[si];
+                        int rtime = -10;
+                        int rstatus = 10;
 
-                        int rstatus = 0;
-                        if (status == "DISQ" || status == "OVRT")
-                            rstatus = 4;
-                        else if (status == "MP" || status == "DNF")
-                            rstatus = 3;
-                        else if (status == "DNS")
-                            rstatus = 1;
+                        switch (status)
+                        {
+                            case "MP":
+                                rstatus = 3;
+                                rtime = -3;
+                                break;
+                            case "DISQ":
+                                rstatus = 4;
+                                break;
+                            case "DNF":
+                                rstatus = 2;
+                                rtime = -3;
+                                break;
+                            case "DNS":
+                                rstatus = 1;
+                                rtime = -3;
+                                break;
+                            case "OVRT":
+                                rstatus = 5;
+                                break;
+                            case "NC":
+                                rstatus = 11;
+                                break;
+                            case "O.K.":
+                                rstatus = 0;
+                                break;
+                        }
 
                         if (rstatus == 0)
                         {
@@ -140,7 +158,7 @@ namespace LiveResults.Client.Parsers
                         }
                         else
                         {
-                            runner.SetResult(-rstatus, rstatus);
+                            runner.SetResult(rtime, rstatus);
                         }
                     }
                 }

--- a/LiveResults.Client/Parsers/RacomFileSetParser.cs
+++ b/LiveResults.Client/Parsers/RacomFileSetParser.cs
@@ -98,7 +98,7 @@ namespace LiveResults.Client.Parsers
                 string tmp;
                 while ((tmp = sr.ReadLine()) != null)
                 {
-                    Dictionary<int,int> teamstatus = new Dictionary<int, int>();
+//                    Dictionary<int,int> teamstatus = new Dictionary<int, int>();
                     if (!string.IsNullOrEmpty(tmp) && !string.IsNullOrEmpty(tmp.Trim()))
                     {
                         int idxColon = tmp.IndexOf(":", StringComparison.Ordinal);
@@ -263,7 +263,7 @@ namespace LiveResults.Client.Parsers
                     if (tmp.Length != 65)
                     {
                         if (OnLogMessage != null)
-                            OnLogMessage("Incorrect start line size ! (lenght is " + tmp.Length + ")");
+                            OnLogMessage("Incorrect start line size ! (length is " + tmp.Length + ")");
                     }
                     try
                     {
@@ -340,9 +340,11 @@ namespace LiveResults.Client.Parsers
         private double parseTime(string start)
         {
             int iDot = start.IndexOf(".", StringComparison.Ordinal);
-            string minutes = start.Substring(0, iDot);
+            bool bMinus = start.IndexOf("-", StringComparison.Ordinal) == 0; // first in -
+            string minutes = start.Substring(bMinus ? 1 : 0, bMinus ? iDot-1: iDot);
             string secs = start.Substring(iDot + 1).Replace(",", ".");
-            return int.Parse(minutes)*60 + double.Parse(secs, CultureInfo.InvariantCulture);
+            double time = int.Parse(minutes) * 60 + double.Parse(secs, CultureInfo.InvariantCulture);
+            return bMinus ? time *= -1 : time;
         }
 
         private bool m_continue = false;

--- a/LiveResults.Client/Properties/Settings.Designer.cs
+++ b/LiveResults.Client/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace LiveResults.Client.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.4.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.10.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/LiveResults.Model/LiveResults.Model.csproj
+++ b/LiveResults.Model/LiveResults.Model.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>LiveResults.Model</RootNamespace>
     <AssemblyName>LiveResults.Model</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>


### PR DESCRIPTION
Racom parser
 - Better result status parsing - similat to IOF XML - now it has complete result status support
 - Updated . NET to version 4.8
 - Fix function parseTime, can handle negative (minus) times 
 - New CSV startlist support.
 - Add dialog has buttons for browse files in settings dialog
 - Add support for read finish time from radio (rawsplits). Finish time doesn't need to wait until readout.
