### PR TITLE
Racom Parser - fix bugs found on WMOC2023

### DIFF
--- a/LiveResults.Client/Parsers/RacomFileSetParser.cs
+++ b/LiveResults.Client/Parsers/RacomFileSetParser.cs
@@ -207,7 +207,7 @@ namespace LiveResults.Client.Parsers
 
                         if (code == finishCode)
                         {
-                            if (runner.Status >= 9)
+                            if (runner.Status == 9 || runner.Status == 10)  // is still pending
                                 runner.SetResult(asTime - runner.StartTime, 0 );
                         }
                         else

--- a/LiveResults.Client/Parsers/RacomFileSetParser.cs
+++ b/LiveResults.Client/Parsers/RacomFileSetParser.cs
@@ -206,7 +206,10 @@ namespace LiveResults.Client.Parsers
                         var asTime = passTime.Hour * 360000 + passTime.Minute * 6000 + passTime.Second * 100 + passTime.Millisecond / 10;
 
                         if (code == finishCode)
-                            runner.SetResult(asTime - runner.StartTime, (runner.Status == 9) ? 0  : runner.Status);
+                        {
+                            if (runner.Status >= 9)
+                                runner.SetResult(asTime - runner.StartTime, 0 );
+                        }
                         else
                         {
                             if (!siSplitPunches.ContainsKey(si))


### PR DESCRIPTION
Racom Parser, fixed bugs :
- fix finish time from rawsplits - correct use of Status values
- fix finish time from rawsplits - used only when runner is not readout

This version of emma client was used on WMOC2023
