### PR TITLE
Updated MySql connector

### DIFF
--- a/LiveResults.Client.Tests/LiveResults.Client.Tests.csproj
+++ b/LiveResults.Client.Tests/LiveResults.Client.Tests.csproj
@@ -110,6 +110,7 @@
       <Link>TestFiles\os2010_splits_sve.csv</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="TestFiles\Racom\Middle\STV00071.CSV" />
     <None Include="TestFiles\Racom\Middle\w_test2\run" />

--- a/LiveResults.Client/App.config
+++ b/LiveResults.Client/App.config
@@ -1,13 +1,40 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
     <!-- URL for server that supplies servers to puch data to -->
-    <add key="serverpollurl" value="https://liveresultat.orientering.se/configs/getConnectionSettings.php"/>
+    <add key="serverpollurl" value="https://liveresultat.orientering.se/configs/getConnectionSettings.php" />
     <!-- Key to get server connection data -->
-    <add key="serverpollkey" value="liveemmaclient"/>
-
+    <add key="serverpollkey" value="liveemmaclient" />
     <!-- OR, add server(s) manually. Format: host;user;pw;db -->
-   <!-- <add key="emmaServer1" value="obasen.nu;liveresultat;web;liveresultat"/>
+    <!-- <add key="emmaServer1" value="obasen.nu;liveresultat;web;liveresultat"/>
     <add key="emmaServer2" value="54.247.102.48;liveresultat;web;liveresultat"/>-->
-    
+    <add key="ClientSettingsProvider.ServiceUri" value="" />
   </appSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
+  </startup>
+  <system.web>
+    <membership defaultProvider="ClientAuthenticationMembershipProvider">
+      <providers>
+        <add name="ClientAuthenticationMembershipProvider" type="System.Web.ClientServices.Providers.ClientFormsAuthenticationMembershipProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" />
+      </providers>
+    </membership>
+    <roleManager defaultProvider="ClientRoleProvider" enabled="true">
+      <providers>
+        <add name="ClientRoleProvider" type="System.Web.ClientServices.Providers.ClientRoleProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" cacheTimeout="86400" />
+      </providers>
+    </roleManager>
+  </system.web>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/LiveResults.Client/LiveResults.Client.csproj
+++ b/LiveResults.Client/LiveResults.Client.csproj
@@ -136,11 +136,16 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MySql.Data, Version=6.2.2.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\References\MySql.Data.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=7.0.0.1, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.7.0.1\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="MySqlConnector, Version=2.0.0.0, Culture=neutral, PublicKeyToken=d33d3e53aa5f8c92, processorArchitecture=MSIL">
+      <HintPath>..\packages\MySqlConnector.2.3.7\lib\net48\MySqlConnector.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.configuration" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
@@ -148,7 +153,24 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />
     <Reference Include="System.Design" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=7.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.7.0.2\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Web.Extensions">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
@@ -285,6 +307,7 @@
     <EmbeddedResource Include="OLEinzel.mlf" />
     <EmbeddedResource Include="OLStaffel.mlf" />
     <None Include="App.config.template" />
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/LiveResults.Client/NewMeosComp.cs
+++ b/LiveResults.Client/NewMeosComp.cs
@@ -164,7 +164,7 @@ namespace LiveResults.Client
         private IDbConnection GetDBConnection(string schema)
         {
 
-            return new MySql.Data.MySqlClient.MySqlConnection("Server=" + txtHost.Text + ";User Id=" + txtUser.Text + ";Port=" + txtPort.Text + ";Password=" + txtPw.Text + (schema != null ? ";Initial Catalog=" + schema : "") + ";charset=utf8;ConnectionTimeout=30");
+            return new MySqlConnector.MySqlConnection("Server=" + txtHost.Text + ";User Id=" + txtUser.Text + ";Port=" + txtPort.Text + ";Password=" + txtPw.Text + (schema != null ? ";Initial Catalog=" + schema : "") + ";charset=utf8;ConnectionTimeout=30");
         }
 
         private void wizardPage3_ShowFromNext(object sender, EventArgs e)

--- a/LiveResults.Client/NewOLAComp.cs
+++ b/LiveResults.Client/NewOLAComp.cs
@@ -224,7 +224,7 @@ namespace LiveResults.Client
                     dbs.Add(r["CATALOG_NAME"] as string);
                 }
             }
-            else if (conn is MySql.Data.MySqlClient.MySqlConnection)
+            else if (conn is MySqlConnector.MySqlConnection)
             {
                 IDbCommand cmd = conn.CreateCommand();
                 cmd.CommandText = "SHOW DATABASES";
@@ -254,7 +254,7 @@ namespace LiveResults.Client
                 case 0:
                     return new H2Connection("jdbc:h2://" + txtOlaDb.Text.Replace(".h2.db","").Replace(".mv.db","") + ";AUTO_SERVER=TRUE", "root", "");
                 case 1:
-                    return new MySql.Data.MySqlClient.MySqlConnection("Server=" + txtHost.Text + ";User Id=" + txtUser.Text + ";Port=" + txtPort.Text + ";Password=" + txtPw.Text + (schema != null ? ";Initial Catalog=" + schema : "") + ";charset=utf8;ConnectionTimeout=30");
+                    return new MySqlConnector.MySqlConnection("Server=" + txtHost.Text + ";User Id=" + txtUser.Text + ";Port=" + txtPort.Text + ";Password=" + txtPw.Text + (schema != null ? ";Initial Catalog=" + schema : "") + ";charset=utf8;ConnectionTimeout=30");
                 case 2:
                     return new OleDbConnection("Provider=SQLOLEDB.1;Persist Security Info=False;User ID=" + txtUser.Text + ";Password=" + txtPw.Text + ";Data Source=" + txtHost.Text + "," + txtPort.Text + (schema != null ? ";Initial Catalog=" + schema : ""));
                     return

--- a/LiveResults.Client/Parsers/OlaParser.cs
+++ b/LiveResults.Client/Parsers/OlaParser.cs
@@ -83,7 +83,7 @@ namespace LiveResults.Client
                     }
 
                     string paramOper = "?";
-                    if (m_connection is MySql.Data.MySqlClient.MySqlConnection)
+                    if (m_connection is MySqlConnector.MySqlConnection)
                     {
                         paramOper = "?date";
                     }
@@ -165,7 +165,7 @@ namespace LiveResults.Client
 
                     IDbDataParameter param = cmd.CreateParameter();
                     param.ParameterName = "date";
-                    if (m_connection is MySql.Data.MySqlClient.MySqlConnection || m_connection is System.Data.H2.H2Connection)
+                    if (m_connection is MySqlConnector.MySqlConnection || m_connection is System.Data.H2.H2Connection)
                     {
                         param.DbType = DbType.String;
                         param.Value = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
@@ -179,7 +179,7 @@ namespace LiveResults.Client
 
                     IDbDataParameter splitparam = cmdSplits.CreateParameter();
                     splitparam.ParameterName = "date";
-                    if (m_connection is MySql.Data.MySqlClient.MySqlConnection || m_connection is System.Data.H2.H2Connection)
+                    if (m_connection is MySqlConnector.MySqlConnection || m_connection is System.Data.H2.H2Connection)
                     {
                         splitparam.DbType = DbType.String;
                         splitparam.Value = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
@@ -208,7 +208,7 @@ namespace LiveResults.Client
                         {
                             /*Kontrollera om nya klasser*/
                             /*Kontrollera om nya resultat*/
-                            if (cmd is MySql.Data.MySqlClient.MySqlCommand || m_connection is System.Data.H2.H2Connection)
+                            if (cmd is MySqlConnector.MySqlCommand || m_connection is System.Data.H2.H2Connection)
                             {
                                 (cmd.Parameters["date"] as IDbDataParameter).Value = lastDateTime.ToString("yyyy-MM-dd HH:mm:ss.fff");
                                 (cmdSplits.Parameters["date"] as IDbDataParameter).Value = lastSplitDateTime.ToString("yyyy-MM-dd HH:mm:ss.fff");

--- a/LiveResults.Model/EmmaMysqlClient.cs
+++ b/LiveResults.Model/EmmaMysqlClient.cs
@@ -1,5 +1,5 @@
 ﻿using System.Globalization;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using System;
 using System.Collections.Generic;
 using System.Configuration;

--- a/LiveResults.Model/LiveResults.Model.csproj
+++ b/LiveResults.Model/LiveResults.Model.csproj
@@ -33,12 +33,35 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MySql.Data">
-      <HintPath>..\References\MySql.Data.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=7.0.0.1, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.7.0.1\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="MySqlConnector, Version=2.0.0.0, Culture=neutral, PublicKeyToken=d33d3e53aa5f8c92, processorArchitecture=MSIL">
+      <HintPath>..\packages\MySqlConnector.2.3.7\lib\net48\MySqlConnector.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=7.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.7.0.2\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -54,6 +77,13 @@
     <Compile Include="Result.cs" />
     <Compile Include="ResultStruct.cs" />
     <Compile Include="Runner.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <WCFMetadata Include="Connected Services\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Changed from MySql.Data.MySqlClient to MySqlConnector to work with MariaDB 10.5.

The old connector MySql.Data.MySqlClient works with MariaDB 10.3 but not MariaDB 10.5.
The updated connector MySqlConnector has been verified to work with MariaDB 10.3 and MariaDB 10.5.
No other verification has been performed.

/Jon Jensen